### PR TITLE
 Add GPIO control for heart rate sensor buzzer

### DIFF
--- a/Buzzer.cpp
+++ b/Buzzer.cpp
@@ -173,7 +173,7 @@ while (1)
 int heartratesensorval = 35;
 
 
-if ((heartratesensorval > 40) && (heartratesensorval < 50))
+if ((heartratesensorval >= 40) && (heartratesensorval <= 50))
 
 {
 


### PR DESCRIPTION
- Implemented GPIO output control to trigger a buzzer when heart rate values fall within the range of 40-50 BPM.
- Added logic to blink the buzzer at 500ms intervals using HAL_GPIO_WritePin and HAL_Delay.
- The variable `heartratesensorval` is set to a placeholder value of 35 for testing purposes.
- Updated the `while` loop to continuously check and trigger the buzzer based on the heart rate threshold.